### PR TITLE
misc/user-security.sh for disabling root and edgy user SSH access

### DIFF
--- a/misc/user-security.sh
+++ b/misc/user-security.sh
@@ -1,0 +1,8 @@
+## curl -o- https://raw.githubusercontent.com/EdgeApp/edge-devops/master/misc/user-security.sh | bash
+
+# This will disable SSH access to root and edgy users.
+# This script should only be run after misc/addusers.sh and password change
+# for at least one administrative user.
+
+echo 'DenyUsers root edgy' > /etc/ssh/sshd_config.d/disable_users.conf
+systemctl restart sshd


### PR DESCRIPTION
This is a misc script to turn off SSH access via root and edgy users. We can implement this routine at the end of other setups/provision scripts.